### PR TITLE
Update for SMAPI 2.0

### DIFF
--- a/ContentInjector.cs
+++ b/ContentInjector.cs
@@ -4,11 +4,6 @@ using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
 using StardewValley;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace JsonAssets
 {

--- a/Mod.cs
+++ b/Mod.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using StardewModdingAPI;
 using System.IO;
 using JsonAssets.Data;
 using StardewModdingAPI.Events;
-using System.Reflection;
 using StardewValley;
 using Microsoft.Xna.Framework;
 using StardewValley.Menus;
@@ -120,8 +117,7 @@ namespace JsonAssets
             cropIds = AssignIds("crops", StartingCropId, crops.ToList<DataNeedsId>());
             fruitTreeIds = AssignIds("fruittrees", StartingFruitTreeId, fruitTrees.ToList<DataNeedsId>());
 
-            var editors = ((IList<IAssetEditor>)helper.Content.GetType().GetProperty("AssetEditors", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance).GetValue(Helper.Content));
-            editors.Add(new ContentInjector());
+            helper.Content.AssetEditors.Add(new ContentInjector());
         }
 
         private void menuChanged(object sender, EventArgsClickableMenuChanged args)

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Json Assets",
   "Author": "spacechase0",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 0,
-    "Build": ""
-  },
+  "Version": "1.0",
   "Description": "Allow custom stuff.",
   "UniqueID": "spacechase0.JsonAssets",
-  "PerSaveConfigs": false,
-  "EntryDll": "JsonAssets.dll"
+  "MinimumApiVersion": "2.0",
+  "EntryDll": "JsonAssets.dll",
+  "UpdateKeys": []
 }


### PR DESCRIPTION
This pull request updates the `manifest.json` for SMAPI 2.0, and replaces reflection used to access the pre-release content API with direct access.