### PR TITLE
Add support for SMAPI 2.5 content packs

### DIFF
--- a/Api.cs
+++ b/Api.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace JsonAssets
 {
@@ -18,9 +14,16 @@ namespace JsonAssets
 
     internal class Api : IApi
     {
+        private readonly Action<string> loadFolder;
+
+        public Api(Action<string> loadFolder)
+        {
+            this.loadFolder = loadFolder;
+        }
+
         public void LoadAssets(string path)
         {
-            Mod.instance.loadData(path);
+            this.loadFolder(path);
         }
 
         public int GetObjectId(string name)

--- a/Data/BigCraftableData.cs
+++ b/Data/BigCraftableData.cs
@@ -1,20 +1,11 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using SObject = StardewValley.Object;
 
 namespace JsonAssets.Data
 {
     public class BigCraftableData : DataNeedsId
     {
-        [JsonIgnore]
-        internal string directory;
-
         [JsonIgnore]
         internal Texture2D texture;
 

--- a/Data/CropData.cs
+++ b/Data/CropData.cs
@@ -1,16 +1,12 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
 
 namespace JsonAssets.Data
 {
     public class CropData : DataNeedsId
     {
-        [JsonIgnore]
-        internal string directory;
-
         [JsonIgnore]
         internal Texture2D texture;
         

--- a/Data/FruitTreeData.cs
+++ b/Data/FruitTreeData.cs
@@ -1,16 +1,11 @@
-﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
 
 namespace JsonAssets.Data
 {
     public class FruitTreeData : DataNeedsId
     {
-        [JsonIgnore]
-        internal string directory;
-
         [JsonIgnore]
         internal Texture2D texture;
         

--- a/Data/ObjectData.cs
+++ b/Data/ObjectData.cs
@@ -1,20 +1,13 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using SObject = StardewValley.Object;
 
 namespace JsonAssets.Data
 {
     public class ObjectData : DataNeedsId
     {
-        [JsonIgnore]
-        internal string directory;
-
         [JsonIgnore]
         internal Texture2D texture;
         [JsonIgnore]

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "Version": "1.0",
   "Description": "Allow custom stuff.",
   "UniqueID": "spacechase0.JsonAssets",
-  "MinimumApiVersion": "2.0",
+  "MinimumApiVersion": "2.5-beta.3",
   "EntryDll": "JsonAssets.dll",
   "UpdateKeys": [ "Nexus:1720" ]
 }


### PR DESCRIPTION
This PR adds support for SMAPI 2.5 content packs, while still supporting the older folders under `JsonAssets/ContentPacks`.

## Background
SMAPI 2.5 adds support for [content packs](https://stardewvalleywiki.com/Modding:Content_packs), which have a few benefits over the custom folder format. They can be installed directly in `Mods`, get automatic update checks and compatibility checks, provide a convenient API to load their contents, and players who forgot to install Json Assets itself will get a friendly error with a link to the mod.

## Implementation notes
I used a SMAPI 2.5 feature to read the previous folders as `IContentPack`, so you can use the same APIs for both. That feature is intended to support the transition to content packs, and will be removed in SMAPI 3.0.

I did that for `Api::LoadAssets` too for now, but that won't work after SMAPI 3.0. You could just create an `IContentPack` wrapper at that point, but it may be worth considering using more specific APIs like `AddCrop(name, ..., texture)` instead of `LoadAssets(string filePath)`. That's up to you though, it's entirely possible to continue supporting `Api::LoadAssets` past SMAPI 3.0.

Tested with [Fantasy Crops](https://www.nexusmods.com/stardewvalley/mods/1610) ([content pack download](https://github.com/spacechase0/JsonAssets/files/1746486/Fantasy_Crops.zip)).

## Migrating old content packs
Migrating the previous format is pretty quick: just replace `content-pack.json` with SMAPI's [`manifest.json`](https://stardewvalleywiki.com/Modding:SMAPI_APIs#Manifest).