### PR TITLE
Refactor ContentInjector1

### DIFF
--- a/ContentInjector1.cs
+++ b/ContentInjector1.cs
@@ -14,56 +14,50 @@ namespace JsonAssets
 {
     public class ContentInjector1 : IAssetEditor
     {
-        private List<string> files;
+        private delegate void injector(IAssetData asset);
+        private Dictionary<string, injector> files;
         public ContentInjector1()
         {
-            files = new List<string>(new string[]
+            Func<string, string> normalize = Mod.instance.Helper.Content.NormalizeAssetName;
+
+            //normalize with 
+            files = new Dictionary<string, injector>()
             {
-                "Data\\ObjectInformation",
-                "Data\\ObjectContextTags",
-                "Data\\Crops",
-                "Data\\fruitTrees",
-                "Data\\CookingRecipes",
-                "Data\\CraftingRecipes",
-                "Data\\BigCraftablesInformation",
-                "Data\\hats",
-                "Data\\weapons",
-                "Data\\ClothingInformation",
-                "Data\\TailoringRecipes",
-                "Data\\Boots",
-                "Maps\\springobjects",
-                "TileSheets\\crops",
-                "TileSheets\\fruitTrees",
-                "TileSheets\\Craftables",
-                "Characters\\Farmer\\hats",
-                "TileSheets\\weapons",
-                "Characters\\Farmer\\shirts",
-                "Characters\\Farmer\\pants",
-                "Characters\\Farmer\\shoeColors"
-            });
+                {normalize("Data\\ObjectInformation"), injectDataObjectInformation},
+                {normalize("Data\\ObjectContextTags"), injectDataObjectContextTags},
+                {normalize("Data\\Crops"), injectDataCrops},
+                {normalize("Data\\fruitTrees"), injectDataFruitTrees},
+                {normalize("Data\\CookingRecipes"), injectDataCookingRecipes},
+                {normalize("Data\\CraftingRecipes"), injectDataCraftingRecipes},
+                {normalize("Data\\BigCraftablesInformation"), injectDataBigCraftablesInformation},
+                {normalize("Data\\hats"), injectDataHats},
+                {normalize("Data\\weapons"), injectDataWeapons},
+                {normalize("Data\\ClothingInformation"), injectDataClothingInformation},
+                {normalize("Data\\TailoringRecipes"), injectDataTailoringRecipes},
+                {normalize("Data\\Boots"), injectDataBoots},
+                {normalize("Maps\\springobjects"), injectMapsSpringobjects},
+                {normalize("TileSheets\\crops"), injectTileSheetsCrops},
+                {normalize("TileSheets\\fruitTrees"), injectTileSheetsFruitTrees},
+                {normalize("TileSheets\\Craftables"), injectTileSheetsCraftables},
+                {normalize("Characters\\Farmer\\hats"), injectCharactersFarmerHats},
+                {normalize("TileSheets\\weapons"), injectTileSheetsWeapons},
+                {normalize("Characters\\Farmer\\shirts"), injectCharactersFarmerShirts},
+                {normalize("Characters\\Farmer\\pants"), injectCharactersFarmerPants},
+                {normalize("Characters\\Farmer\\shoeColors"), injectCharactersFarmerShoeColors}
+            };
         }
 
         public void InvalidateUsed()
         {
             Mod.instance.Helper.Content.InvalidateCache((a) =>
             {
-                foreach (var file in files)
-                {
-                    if (a.AssetNameEquals(file))
-                        return true;
-                }
-                return false;
+                return files.ContainsKey(a.AssetName);
             });
         }
 
         public bool CanEdit<T>(IAssetInfo asset)
         {
-            foreach (var file in files )
-            {
-                if (asset.AssetNameEquals(file))
-                    return true;
-            }
-            return false;
+            return files.ContainsKey(asset.AssetName);
         }
 
         public void Edit<T>(IAssetData asset)
@@ -71,92 +65,9 @@ namespace JsonAssets
             if (!Mod.instance.didInit)
                 return;
 
-            if (asset.AssetNameEquals("Data\\ObjectInformation"))
-            {
-                injectDataObjectInformation(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\ObjectContextTags"))
-            {
-                injectDataObjectContextTags(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\Crops"))
-            {
-                injectDataCrops(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\fruitTrees"))
-            {
-                injectDataFruitTrees(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\CookingRecipes"))
-            {
-                injectDataCookingRecipes(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\CraftingRecipes"))
-            {
-                injectDataCraftingRecipes(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\BigCraftablesInformation"))
-            {
-                injectDataBigCraftablesInformation(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\hats"))
-            {
-                injectDataHats(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\weapons"))
-            {
-                injectDataWeapons(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\ClothingInformation"))
-            {
-                injectDataClothingInformation(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\TailoringRecipes"))
-            {
-                injectDataTailoringRecipes(asset);
-            }
-            else if (asset.AssetNameEquals("Data\\Boots"))
-            {
-                injectDataBoots(asset);
-            }
-            else if (asset.AssetNameEquals("Maps\\springobjects"))
-            {
-                injectMapsSpringobjects(asset);
-            }
-            else if (asset.AssetNameEquals("TileSheets\\crops"))
-            {
-                injectTileSheetsCrops(asset);
-            }
-            else if (asset.AssetNameEquals("TileSheets\\fruitTrees"))
-            {
-                injectTileSheetsFruitTrees(asset);
-            }
-            else if (asset.AssetNameEquals("TileSheets\\Craftables"))
-            {
-                injectTileSheetsCraftables(asset);
-            }
-            else if (asset.AssetNameEquals("Characters\\Farmer\\hats"))
-            {
-                injectCharactersFarmerHats(asset);
-            }
-            else if (asset.AssetNameEquals("TileSheets\\weapons"))
-            {
-                injectTileSheetsWeapons(asset);
-            }
-            else if (asset.AssetNameEquals("Characters\\Farmer\\shirts"))
-            {
-                injectCharactersFarmerShirts(asset);
-            }
-            else if (asset.AssetNameEquals("Characters\\Farmer\\pants"))
-            {
-                injectCharactersFarmerPants(asset);
-            }
-            else if (asset.AssetNameEquals("Characters\\Farmer\\shoeColors"))
-            {
-                injectCharactersFarmerShoeColors(asset);
-            }
+            files[asset.AssetName](asset);
         }
-        //IAssetData asset
+
         private void injectDataObjectInformation(IAssetData asset)
         {
             var data = asset.AsDictionary<int, string>().Data;

--- a/ContentInjector1.cs
+++ b/ContentInjector1.cs
@@ -73,504 +73,589 @@ namespace JsonAssets
 
             if (asset.AssetNameEquals("Data\\ObjectInformation"))
             {
-                var data = asset.AsDictionary<int, string>().Data;
-                foreach (var obj in Mod.instance.objects)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to objects: {obj.GetObjectId()}: {obj.GetObjectInformation()}");
-                        data.Add(obj.GetObjectId(), obj.GetObjectInformation());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting object information for {obj.Name}: {e}");
-                    }
-                }
+                injectDataObjectInformation(asset);
             }
             else if (asset.AssetNameEquals("Data\\ObjectContextTags"))
             {
-                var data = asset.AsDictionary<string, string>().Data;
-                foreach (var obj in Mod.instance.objects)
-                {
-                    try
-                    {
-                        string tags = string.Join(", ", obj.ContextTags);
-                        Log.verbose($"Injecting to object context tags: {obj.Name}: {tags}");
-                        if (data.ContainsKey(obj.Name) && data[obj.Name] == "")
-                            data[obj.Name] = tags;
-                        else
-                            data.Add(obj.Name, tags);
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting object context tags for {obj.Name}: {e}");
-                    }
-                }
+                injectDataObjectContextTags(asset);
             }
             else if (asset.AssetNameEquals("Data\\Crops"))
             {
-                var data = asset.AsDictionary<int, string>().Data;
-                foreach (var crop in Mod.instance.crops)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to crops: {crop.GetSeedId()}: {crop.GetCropInformation()}");
-                        data.Add(crop.GetSeedId(), crop.GetCropInformation());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting crop for {crop.Name}: {e}");
-                    }
-                }
+                injectDataCrops(asset);
             }
             else if (asset.AssetNameEquals("Data\\fruitTrees"))
             {
-                var data = asset.AsDictionary<int, string>().Data;
-                foreach (var fruitTree in Mod.instance.fruitTrees)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to fruit trees: {fruitTree.GetSaplingId()}: {fruitTree.GetFruitTreeInformation()}");
-                        data.Add(fruitTree.GetSaplingId(), fruitTree.GetFruitTreeInformation());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting fruit tree for {fruitTree.Name}: {e}");
-                    }
-                }
+                injectDataFruitTrees(asset);
             }
             else if (asset.AssetNameEquals("Data\\CookingRecipes"))
             {
-                var data = asset.AsDictionary<string, string>().Data;
-                foreach (var obj in Mod.instance.objects)
-                {
-                    try
-                    {
-                        if (obj.Recipe == null)
-                            continue;
-                        if (obj.Category != ObjectData.Category_.Cooking)
-                            continue;
-                        Log.verbose($"Injecting to cooking recipes: {obj.Name}: {obj.Recipe.GetRecipeString(obj)}");
-                        data.Add(obj.Name, obj.Recipe.GetRecipeString(obj));
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting cooking recipe for {obj.Name}: {e}");
-                    }
-                }
+                injectDataCookingRecipes(asset);
             }
             else if (asset.AssetNameEquals("Data\\CraftingRecipes"))
             {
-                var data = asset.AsDictionary<string, string>().Data;
-                foreach (var obj in Mod.instance.objects)
-                {
-                    try
-                    {
-                        if (obj.Recipe == null)
-                            continue;
-                        if (obj.Category == ObjectData.Category_.Cooking)
-                            continue;
-                        Log.verbose($"Injecting to crafting recipes: {obj.Name}: {obj.Recipe.GetRecipeString(obj)}");
-                        data.Add(obj.Name, obj.Recipe.GetRecipeString(obj));
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting crafting recipe for {obj.Name}: {e}");
-                    }
-                }
-                foreach (var big in Mod.instance.bigCraftables)
-                {
-                    try
-                    {
-                        if (big.Recipe == null)
-                            continue;
-                        Log.verbose($"Injecting to crafting recipes: {big.Name}: {big.Recipe.GetRecipeString(big)}");
-                        data.Add(big.Name, big.Recipe.GetRecipeString(big));
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting crafting recipe for {big.Name}: {e}");
-                    }
-                }
+                injectDataCraftingRecipes(asset);
             }
             else if (asset.AssetNameEquals("Data\\BigCraftablesInformation"))
             {
-                var data = asset.AsDictionary<int, string>().Data;
-                foreach (var big in Mod.instance.bigCraftables)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to big craftables: {big.GetCraftableId()}: {big.GetCraftableInformation()}");
-                        data.Add(big.GetCraftableId(), big.GetCraftableInformation());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting object information for {big.Name}: {e}");
-                    }
-                }
+                injectDataBigCraftablesInformation(asset);
             }
             else if (asset.AssetNameEquals("Data\\hats"))
             {
-                var data = asset.AsDictionary<int, string>().Data;
-                foreach (var hat in Mod.instance.hats)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to hats: {hat.GetHatId()}: {hat.GetHatInformation()}");
-                        data.Add(hat.GetHatId(), hat.GetHatInformation());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting hat information for {hat.Name}: {e}");
-                    }
-                }
+                injectDataHats(asset);
             }
             else if (asset.AssetNameEquals("Data\\weapons"))
             {
-                var data = asset.AsDictionary<int, string>().Data;
-                foreach (var weapon in Mod.instance.weapons)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to weapons: {weapon.GetWeaponId()}: {weapon.GetWeaponInformation()}");
-                        data.Add(weapon.GetWeaponId(), weapon.GetWeaponInformation());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting weapon information for {weapon.Name}: {e}");
-                    }
-                }
+                injectDataWeapons(asset);
             }
             else if (asset.AssetNameEquals("Data\\ClothingInformation"))
             {
-                var data = asset.AsDictionary<int, string>().Data;
-                foreach (var shirt in Mod.instance.shirts)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to clothing information: {shirt.GetClothingId()}: {shirt.GetClothingInformation()}");
-                        data.Add(shirt.GetClothingId(), shirt.GetClothingInformation());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting clothing information for {shirt.Name}: {e}");
-                    }
-                }
-                foreach (var pants in Mod.instance.pantss)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to clothing information: {pants.GetClothingId()}: {pants.GetClothingInformation()}");
-                        data.Add(pants.GetClothingId(), pants.GetClothingInformation());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting clothing information for {pants.Name}: {e}");
-                    }
-                }
+                injectDataClothingInformation(asset);
             }
             else if (asset.AssetNameEquals("Data\\TailoringRecipes"))
             {
-                var data = asset.GetData<List<TailorItemRecipe>>();
-                foreach (var recipe in Mod.instance.tailoring)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to tailoring recipe: {recipe.ToGameData()}");
-                        data.Add(recipe.ToGameData());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting tailoring recipe: {e}");
-                    }
-                }
+                injectDataTailoringRecipes(asset);
             }
             else if (asset.AssetNameEquals("Data\\Boots"))
             {
-                var data = asset.AsDictionary<int, string>().Data;
-                foreach (var boots in Mod.instance.bootss)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting to boots: {boots.GetObjectId()}: {boots.GetBootsInformation()}");
-                        data.Add(boots.GetObjectId(), boots.GetBootsInformation());
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting boots information for {boots.Name}: {e}");
-                    }
-                }
+                injectDataBoots(asset);
             }
             else if (asset.AssetNameEquals("Maps\\springobjects"))
             {
-                var oldTex = asset.AsImage().Data;
-                Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
-                asset.ReplaceWith(newTex);
-                asset.AsImage().PatchImage(oldTex);
-
-                foreach (var obj in Mod.instance.objects)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting {obj.Name} sprites @ {objectRect(obj.GetObjectId())}");
-                        asset.AsImage().PatchImage(obj.texture, null, objectRect(obj.GetObjectId()));
-                        if (obj.IsColored)
-                        {
-                            Log.verbose($"Injecting {obj.Name} color sprites @ {objectRect(obj.GetObjectId() + 1)}");
-                            asset.AsImage().PatchImage(obj.textureColor, null, objectRect(obj.GetObjectId() + 1));
-                        }
-
-                        var rect = objectRect(obj.GetObjectId());
-                        int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
-                        obj.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
-                        obj.tilesheetX = rect.X;
-                        obj.tilesheetY = rect.Y;
-                    }
-                    catch ( Exception e )
-                    {
-                        Log.error($"Exception injecting sprite for {obj.Name}: {e}");
-                    }
-                }
-
-                foreach (var boots in Mod.instance.bootss)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting {boots.Name} sprites @ {objectRect(boots.GetObjectId())}");
-                        asset.AsImage().PatchImage(boots.texture, null, objectRect(boots.GetObjectId()));
-
-                        var rect = objectRect(boots.GetObjectId());
-                        int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
-                        boots.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
-                        boots.tilesheetX = rect.X;
-                        boots.tilesheetY = rect.Y;
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting sprite for {boots.Name}: {e}");
-                    }
-                }
+                injectMapsSpringobjects(asset);
             }
             else if (asset.AssetNameEquals("TileSheets\\crops"))
             {
-                var oldTex = asset.AsImage().Data;
-                Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
-                asset.ReplaceWith(newTex);
-                asset.AsImage().PatchImage(oldTex);
-
-                foreach (var crop in Mod.instance.crops)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting {crop.Name} crop images @ {cropRect(crop.GetCropSpriteIndex())}");
-                        asset.AsImage().PatchExtendedTileSheet(crop.texture, null, cropRect(crop.GetCropSpriteIndex()));
-                        
-                        var rect = cropRect(crop.GetCropSpriteIndex());
-                        int ts = TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
-                        crop.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
-                        crop.tilesheetX = rect.X;
-                        crop.tilesheetY = rect.Y;
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting crop sprite for {crop.Name}: {e}");
-                    }
-                }
+                injectTileSheetsCrops(asset);
             }
             else if (asset.AssetNameEquals("TileSheets\\fruitTrees"))
             {
-                var oldTex = asset.AsImage().Data;
-                Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
-                asset.ReplaceWith(newTex);
-                asset.AsImage().PatchImage(oldTex);
-
-                foreach (var fruitTree in Mod.instance.fruitTrees)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting {fruitTree.Name} fruit tree images @ {fruitTreeRect(fruitTree.GetFruitTreeIndex())}");
-                        asset.AsImage().PatchExtendedTileSheet(fruitTree.texture, null, fruitTreeRect(fruitTree.GetFruitTreeIndex()));
-                        
-                        var rect = fruitTreeRect(fruitTree.GetFruitTreeIndex());
-                        int ts = TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
-                        fruitTree.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
-                        fruitTree.tilesheetX = rect.X;
-                        fruitTree.tilesheetY = rect.Y;
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting fruit tree sprite for {fruitTree.Name}: {e}");
-                    }
-                }
+                injectTileSheetsFruitTrees(asset);
             }
             else if (asset.AssetNameEquals("TileSheets\\Craftables"))
             {
-                var oldTex = asset.AsImage().Data;
-                Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
-                asset.ReplaceWith(newTex);
-                asset.AsImage().PatchImage(oldTex);
-                Log.trace($"Big craftables are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
-
-                foreach (var big in Mod.instance.bigCraftables)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting {big.Name} sprites @ {bigCraftableRect(big.GetCraftableId())}");
-                        asset.AsImage().PatchImage(big.texture, null, bigCraftableRect(big.GetCraftableId()));
-                        if (big.ReserveExtraIndexCount > 0)
-                        {
-                            for ( int i = 0; i < big.ReserveExtraIndexCount; ++i )
-                            {
-                                Log.verbose($"Injecting {big.Name} reserved extra sprite {i + 1} @ {bigCraftableRect(big.GetCraftableId() + i + 1)}");
-                                asset.AsImage().PatchImage(big.extraTextures[i], null, bigCraftableRect(big.GetCraftableId() + i + 1));
-                            }
-                        }
-
-                        var rect = bigCraftableRect(big.GetCraftableId());
-                        int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
-                        big.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
-                        big.tilesheetX = rect.X;
-                        big.tilesheetY = rect.Y;
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting sprite for {big.Name}: {e}");
-                    }
-                }
+                injectTileSheetsCraftables(asset);
             }
             else if (asset.AssetNameEquals("Characters\\Farmer\\hats"))
             {
-                var oldTex = asset.AsImage().Data;
-                Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
-                asset.ReplaceWith(newTex);
-                asset.AsImage().PatchImage(oldTex);
-                Log.trace($"Hats are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
-
-                foreach (var hat in Mod.instance.hats)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting {hat.Name} sprites @ {hatRect(hat.GetHatId())}");
-                        asset.AsImage().PatchImage(hat.texture, null, hatRect(hat.GetHatId()));
-
-                        var rect = hatRect(hat.GetHatId());
-                        int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
-                        hat.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
-                        hat.tilesheetX = rect.X;
-                        hat.tilesheetY = rect.Y;
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting sprite for {hat.Name}: {e}");
-                    }
-                }
+                injectCharactersFarmerHats(asset);
             }
             else if (asset.AssetNameEquals("TileSheets\\weapons"))
             {
-                var oldTex = asset.AsImage().Data;
-                Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
-                asset.ReplaceWith(newTex);
-                asset.AsImage().PatchImage(oldTex);
-                Log.trace($"Weapons are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
-
-                foreach (var weapon in Mod.instance.weapons)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting {weapon.Name} sprites @ {weaponRect(weapon.GetWeaponId())}");
-                        asset.AsImage().PatchImage(weapon.texture, null, weaponRect(weapon.GetWeaponId()));
-
-                        var rect = weaponRect(weapon.GetWeaponId());
-                        int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
-                        weapon.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
-                        weapon.tilesheetX = rect.X;
-                        weapon.tilesheetY = rect.Y;
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting sprite for {weapon.Name}: {e}");
-                    }
-                }
+                injectTileSheetsWeapons(asset);
             }
             else if (asset.AssetNameEquals("Characters\\Farmer\\shirts"))
             {
-                var oldTex = asset.AsImage().Data;
-                Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
-                asset.ReplaceWith(newTex);
-                asset.AsImage().PatchImage(oldTex);
-                Log.trace($"Shirts are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
-
-                foreach (var shirt in Mod.instance.shirts)
-                {
-                    try
-                    {
-                        string rects = shirtRectPlain(shirt.GetMaleIndex()).ToString();
-                        if (shirt.Dyeable)
-                            rects += ", " + shirtRectDye(shirt.GetMaleIndex()).ToString();
-                        if (shirt.HasFemaleVariant)
-                        {
-                            rects += ", " + shirtRectPlain(shirt.GetFemaleIndex()).ToString();
-                            if (shirt.Dyeable)
-                                rects += ", " + shirtRectDye(shirt.GetFemaleIndex()).ToString();
-                        }
-
-                        Log.verbose($"Injecting {shirt.Name} sprites @ {rects}");
-                        asset.AsImage().PatchExtendedTileSheet(shirt.textureMale, null, shirtRectPlain(shirt.GetMaleIndex()));
-                        if (shirt.Dyeable)
-                            asset.AsImage().PatchExtendedTileSheet(shirt.textureMaleColor, null, shirtRectDye(shirt.GetMaleIndex()));
-                        if (shirt.HasFemaleVariant)
-                        {
-                            asset.AsImage().PatchExtendedTileSheet(shirt.textureFemale, null, shirtRectPlain(shirt.GetFemaleIndex()));
-                            if (shirt.Dyeable)
-                                asset.AsImage().PatchExtendedTileSheet(shirt.textureFemaleColor, null, shirtRectDye(shirt.GetFemaleIndex()));
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting sprite for {shirt.Name}: {e}");
-                    }
-                }
+                injectCharactersFarmerShirts(asset);
             }
             else if (asset.AssetNameEquals("Characters\\Farmer\\pants"))
             {
-                var oldTex = asset.AsImage().Data;
-                Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
-                asset.ReplaceWith(newTex);
-                asset.AsImage().PatchImage(oldTex);
-                Log.trace($"Pants are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
-
-                foreach (var pants in Mod.instance.pantss)
-                {
-                    try
-                    {
-                        Log.verbose($"Injecting {pants.Name} sprites @ {pantsRect(pants.GetTextureIndex())}");
-                        asset.AsImage().PatchExtendedTileSheet(pants.texture, null, pantsRect(pants.GetTextureIndex()));
-                    }
-                    catch (Exception e)
-                    {
-                        Log.error($"Exception injecting sprite for {pants.Name}: {e}");
-                    }
-                }
+                injectCharactersFarmerPants(asset);
             }
             else if (asset.AssetNameEquals("Characters\\Farmer\\shoeColors"))
             {
-                var oldTex = asset.AsImage().Data;
-                Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
-                asset.ReplaceWith(newTex);
-                asset.AsImage().PatchImage(oldTex);
-                Log.trace($"Boots are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
-
-                foreach (var boots in Mod.instance.bootss)
+                injectCharactersFarmerShoeColors(asset);
+            }
+        }
+        //IAssetData asset
+        private void injectDataObjectInformation(IAssetData asset)
+        {
+            var data = asset.AsDictionary<int, string>().Data;
+            foreach (var obj in Mod.instance.objects)
+            {
+                try
                 {
-                    try
+                    Log.verbose($"Injecting to objects: {obj.GetObjectId()}: {obj.GetObjectInformation()}");
+                    data.Add(obj.GetObjectId(), obj.GetObjectInformation());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting object information for {obj.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataObjectContextTags(IAssetData asset)
+        {
+            var data = asset.AsDictionary<string, string>().Data;
+            foreach (var obj in Mod.instance.objects)
+            {
+                try
+                {
+                    string tags = string.Join(", ", obj.ContextTags);
+                    Log.verbose($"Injecting to object context tags: {obj.Name}: {tags}");
+                    if (data.ContainsKey(obj.Name) && data[obj.Name] == "")
+                        data[obj.Name] = tags;
+                    else
+                        data.Add(obj.Name, tags);
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting object context tags for {obj.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataCrops(IAssetData asset)
+        {
+            var data = asset.AsDictionary<int, string>().Data;
+            foreach (var crop in Mod.instance.crops)
+            {
+                try
+                {
+                    Log.verbose($"Injecting to crops: {crop.GetSeedId()}: {crop.GetCropInformation()}");
+                    data.Add(crop.GetSeedId(), crop.GetCropInformation());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting crop for {crop.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataFruitTrees(IAssetData asset)
+        {
+            var data = asset.AsDictionary<int, string>().Data;
+            foreach (var fruitTree in Mod.instance.fruitTrees)
+            {
+                try
+                {
+                    Log.verbose($"Injecting to fruit trees: {fruitTree.GetSaplingId()}: {fruitTree.GetFruitTreeInformation()}");
+                    data.Add(fruitTree.GetSaplingId(), fruitTree.GetFruitTreeInformation());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting fruit tree for {fruitTree.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataCookingRecipes(IAssetData asset)
+        {
+            var data = asset.AsDictionary<string, string>().Data;
+            foreach (var obj in Mod.instance.objects)
+            {
+                try
+                {
+                    if (obj.Recipe == null)
+                        continue;
+                    if (obj.Category != ObjectData.Category_.Cooking)
+                        continue;
+                    Log.verbose($"Injecting to cooking recipes: {obj.Name}: {obj.Recipe.GetRecipeString(obj)}");
+                    data.Add(obj.Name, obj.Recipe.GetRecipeString(obj));
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting cooking recipe for {obj.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataCraftingRecipes(IAssetData asset)
+        {
+            var data = asset.AsDictionary<string, string>().Data;
+            foreach (var obj in Mod.instance.objects)
+            {
+                try
+                {
+                    if (obj.Recipe == null)
+                        continue;
+                    if (obj.Category == ObjectData.Category_.Cooking)
+                        continue;
+                    Log.verbose($"Injecting to crafting recipes: {obj.Name}: {obj.Recipe.GetRecipeString(obj)}");
+                    data.Add(obj.Name, obj.Recipe.GetRecipeString(obj));
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting crafting recipe for {obj.Name}: {e}");
+                }
+            }
+            foreach (var big in Mod.instance.bigCraftables)
+            {
+                try
+                {
+                    if (big.Recipe == null)
+                        continue;
+                    Log.verbose($"Injecting to crafting recipes: {big.Name}: {big.Recipe.GetRecipeString(big)}");
+                    data.Add(big.Name, big.Recipe.GetRecipeString(big));
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting crafting recipe for {big.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataBigCraftablesInformation(IAssetData asset)
+        {
+            var data = asset.AsDictionary<int, string>().Data;
+            foreach (var big in Mod.instance.bigCraftables)
+            {
+                try
+                {
+                    Log.verbose($"Injecting to big craftables: {big.GetCraftableId()}: {big.GetCraftableInformation()}");
+                    data.Add(big.GetCraftableId(), big.GetCraftableInformation());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting object information for {big.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataHats(IAssetData asset)
+        {
+            var data = asset.AsDictionary<int, string>().Data;
+            foreach (var hat in Mod.instance.hats)
+            {
+                try
+                {
+                    Log.verbose($"Injecting to hats: {hat.GetHatId()}: {hat.GetHatInformation()}");
+                    data.Add(hat.GetHatId(), hat.GetHatInformation());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting hat information for {hat.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataWeapons(IAssetData asset)
+        {
+            var data = asset.AsDictionary<int, string>().Data;
+            foreach (var weapon in Mod.instance.weapons)
+            {
+                try
+                {
+                    Log.verbose($"Injecting to weapons: {weapon.GetWeaponId()}: {weapon.GetWeaponInformation()}");
+                    data.Add(weapon.GetWeaponId(), weapon.GetWeaponInformation());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting weapon information for {weapon.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataClothingInformation(IAssetData asset)
+        {
+            var data = asset.AsDictionary<int, string>().Data;
+            foreach (var shirt in Mod.instance.shirts)
+            {
+                try
+                {
+                    Log.verbose($"Injecting to clothing information: {shirt.GetClothingId()}: {shirt.GetClothingInformation()}");
+                    data.Add(shirt.GetClothingId(), shirt.GetClothingInformation());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting clothing information for {shirt.Name}: {e}");
+                }
+            }
+            foreach (var pants in Mod.instance.pantss)
+            {
+                try
+                {
+                    Log.verbose($"Injecting to clothing information: {pants.GetClothingId()}: {pants.GetClothingInformation()}");
+                    data.Add(pants.GetClothingId(), pants.GetClothingInformation());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting clothing information for {pants.Name}: {e}");
+                }
+            }
+        }
+        private void injectDataTailoringRecipes(IAssetData asset)
+        {
+            var data = asset.GetData<List<TailorItemRecipe>>();
+            foreach (var recipe in Mod.instance.tailoring)
+            {
+                try
+                {
+                    Log.verbose($"Injecting to tailoring recipe: {recipe.ToGameData()}");
+                    data.Add(recipe.ToGameData());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting tailoring recipe: {e}");
+                }
+            }
+        }
+        private void injectDataBoots(IAssetData asset)
+        {
+            var data = asset.AsDictionary<int, string>().Data;
+            foreach (var boots in Mod.instance.bootss)
+            {
+                try
+                {
+                    Log.verbose($"Injecting to boots: {boots.GetObjectId()}: {boots.GetBootsInformation()}");
+                    data.Add(boots.GetObjectId(), boots.GetBootsInformation());
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting boots information for {boots.Name}: {e}");
+                }
+            }
+        }
+        private void injectMapsSpringobjects(IAssetData asset)
+        {
+            var oldTex = asset.AsImage().Data;
+            Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
+            asset.ReplaceWith(newTex);
+            asset.AsImage().PatchImage(oldTex);
+
+            foreach (var obj in Mod.instance.objects)
+            {
+                try
+                {
+                    Log.verbose($"Injecting {obj.Name} sprites @ {objectRect(obj.GetObjectId())}");
+                    asset.AsImage().PatchImage(obj.texture, null, objectRect(obj.GetObjectId()));
+                    if (obj.IsColored)
                     {
-                        Log.verbose($"Injecting {boots.Name} sprites @ {bootsRect(boots.GetTextureIndex())}");
-                        asset.AsImage().PatchExtendedTileSheet(boots.textureColor, null, bootsRect(boots.GetTextureIndex()));
+                        Log.verbose($"Injecting {obj.Name} color sprites @ {objectRect(obj.GetObjectId() + 1)}");
+                        asset.AsImage().PatchImage(obj.textureColor, null, objectRect(obj.GetObjectId() + 1));
                     }
-                    catch (Exception e)
+
+                    var rect = objectRect(obj.GetObjectId());
+                    int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
+                    obj.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
+                    obj.tilesheetX = rect.X;
+                    obj.tilesheetY = rect.Y;
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting sprite for {obj.Name}: {e}");
+                }
+            }
+
+            foreach (var boots in Mod.instance.bootss)
+            {
+                try
+                {
+                    Log.verbose($"Injecting {boots.Name} sprites @ {objectRect(boots.GetObjectId())}");
+                    asset.AsImage().PatchImage(boots.texture, null, objectRect(boots.GetObjectId()));
+
+                    var rect = objectRect(boots.GetObjectId());
+                    int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
+                    boots.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
+                    boots.tilesheetX = rect.X;
+                    boots.tilesheetY = rect.Y;
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting sprite for {boots.Name}: {e}");
+                }
+            }
+        }
+        private void injectTileSheetsCrops(IAssetData asset)
+        {
+            var oldTex = asset.AsImage().Data;
+            Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
+            asset.ReplaceWith(newTex);
+            asset.AsImage().PatchImage(oldTex);
+
+            foreach (var crop in Mod.instance.crops)
+            {
+                try
+                {
+                    Log.verbose($"Injecting {crop.Name} crop images @ {cropRect(crop.GetCropSpriteIndex())}");
+                    asset.AsImage().PatchExtendedTileSheet(crop.texture, null, cropRect(crop.GetCropSpriteIndex()));
+
+                    var rect = cropRect(crop.GetCropSpriteIndex());
+                    int ts = TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
+                    crop.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
+                    crop.tilesheetX = rect.X;
+                    crop.tilesheetY = rect.Y;
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting crop sprite for {crop.Name}: {e}");
+                }
+            }
+        }
+        private void injectTileSheetsFruitTrees(IAssetData asset)
+        {
+            var oldTex = asset.AsImage().Data;
+            Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
+            asset.ReplaceWith(newTex);
+            asset.AsImage().PatchImage(oldTex);
+
+            foreach (var fruitTree in Mod.instance.fruitTrees)
+            {
+                try
+                {
+                    Log.verbose($"Injecting {fruitTree.Name} fruit tree images @ {fruitTreeRect(fruitTree.GetFruitTreeIndex())}");
+                    asset.AsImage().PatchExtendedTileSheet(fruitTree.texture, null, fruitTreeRect(fruitTree.GetFruitTreeIndex()));
+
+                    var rect = fruitTreeRect(fruitTree.GetFruitTreeIndex());
+                    int ts = TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
+                    fruitTree.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
+                    fruitTree.tilesheetX = rect.X;
+                    fruitTree.tilesheetY = rect.Y;
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting fruit tree sprite for {fruitTree.Name}: {e}");
+                }
+            }
+        }
+        private void injectTileSheetsCraftables(IAssetData asset)
+        {
+            var oldTex = asset.AsImage().Data;
+            Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
+            asset.ReplaceWith(newTex);
+            asset.AsImage().PatchImage(oldTex);
+            Log.trace($"Big craftables are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
+
+            foreach (var big in Mod.instance.bigCraftables)
+            {
+                try
+                {
+                    Log.verbose($"Injecting {big.Name} sprites @ {bigCraftableRect(big.GetCraftableId())}");
+                    asset.AsImage().PatchImage(big.texture, null, bigCraftableRect(big.GetCraftableId()));
+                    if (big.ReserveExtraIndexCount > 0)
                     {
-                        Log.error($"Exception injecting sprite for {boots.Name}: {e}");
+                        for (int i = 0; i < big.ReserveExtraIndexCount; ++i)
+                        {
+                            Log.verbose($"Injecting {big.Name} reserved extra sprite {i + 1} @ {bigCraftableRect(big.GetCraftableId() + i + 1)}");
+                            asset.AsImage().PatchImage(big.extraTextures[i], null, bigCraftableRect(big.GetCraftableId() + i + 1));
+                        }
                     }
+
+                    var rect = bigCraftableRect(big.GetCraftableId());
+                    int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
+                    big.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
+                    big.tilesheetX = rect.X;
+                    big.tilesheetY = rect.Y;
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting sprite for {big.Name}: {e}");
+                }
+            }
+        }
+        private void injectCharactersFarmerHats(IAssetData asset)
+        {
+            var oldTex = asset.AsImage().Data;
+            Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
+            asset.ReplaceWith(newTex);
+            asset.AsImage().PatchImage(oldTex);
+            Log.trace($"Hats are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
+
+            foreach (var hat in Mod.instance.hats)
+            {
+                try
+                {
+                    Log.verbose($"Injecting {hat.Name} sprites @ {hatRect(hat.GetHatId())}");
+                    asset.AsImage().PatchImage(hat.texture, null, hatRect(hat.GetHatId()));
+
+                    var rect = hatRect(hat.GetHatId());
+                    int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
+                    hat.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
+                    hat.tilesheetX = rect.X;
+                    hat.tilesheetY = rect.Y;
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting sprite for {hat.Name}: {e}");
+                }
+            }
+        }
+        private void injectTileSheetsWeapons(IAssetData asset)
+        {
+            var oldTex = asset.AsImage().Data;
+            Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
+            asset.ReplaceWith(newTex);
+            asset.AsImage().PatchImage(oldTex);
+            Log.trace($"Weapons are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
+
+            foreach (var weapon in Mod.instance.weapons)
+            {
+                try
+                {
+                    Log.verbose($"Injecting {weapon.Name} sprites @ {weaponRect(weapon.GetWeaponId())}");
+                    asset.AsImage().PatchImage(weapon.texture, null, weaponRect(weapon.GetWeaponId()));
+
+                    var rect = weaponRect(weapon.GetWeaponId());
+                    int ts = 0;// TileSheetExtensions.GetAdjustedTileSheetTarget(asset.AssetName, rect).TileSheet;
+                    weapon.tilesheet = asset.AssetName + (ts == 0 ? "" : (ts + 1).ToString());
+                    weapon.tilesheetX = rect.X;
+                    weapon.tilesheetY = rect.Y;
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting sprite for {weapon.Name}: {e}");
+                }
+            }
+        }
+        private void injectCharactersFarmerShirts(IAssetData asset)
+        {
+            var oldTex = asset.AsImage().Data;
+            Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
+            asset.ReplaceWith(newTex);
+            asset.AsImage().PatchImage(oldTex);
+            Log.trace($"Shirts are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
+
+            foreach (var shirt in Mod.instance.shirts)
+            {
+                try
+                {
+                    string rects = shirtRectPlain(shirt.GetMaleIndex()).ToString();
+                    if (shirt.Dyeable)
+                        rects += ", " + shirtRectDye(shirt.GetMaleIndex()).ToString();
+                    if (shirt.HasFemaleVariant)
+                    {
+                        rects += ", " + shirtRectPlain(shirt.GetFemaleIndex()).ToString();
+                        if (shirt.Dyeable)
+                            rects += ", " + shirtRectDye(shirt.GetFemaleIndex()).ToString();
+                    }
+
+                    Log.verbose($"Injecting {shirt.Name} sprites @ {rects}");
+                    asset.AsImage().PatchExtendedTileSheet(shirt.textureMale, null, shirtRectPlain(shirt.GetMaleIndex()));
+                    if (shirt.Dyeable)
+                        asset.AsImage().PatchExtendedTileSheet(shirt.textureMaleColor, null, shirtRectDye(shirt.GetMaleIndex()));
+                    if (shirt.HasFemaleVariant)
+                    {
+                        asset.AsImage().PatchExtendedTileSheet(shirt.textureFemale, null, shirtRectPlain(shirt.GetFemaleIndex()));
+                        if (shirt.Dyeable)
+                            asset.AsImage().PatchExtendedTileSheet(shirt.textureFemaleColor, null, shirtRectDye(shirt.GetFemaleIndex()));
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting sprite for {shirt.Name}: {e}");
+                }
+            }
+        }
+        private void injectCharactersFarmerPants(IAssetData asset)
+        {
+            var oldTex = asset.AsImage().Data;
+            Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
+            asset.ReplaceWith(newTex);
+            asset.AsImage().PatchImage(oldTex);
+            Log.trace($"Pants are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
+
+            foreach (var pants in Mod.instance.pantss)
+            {
+                try
+                {
+                    Log.verbose($"Injecting {pants.Name} sprites @ {pantsRect(pants.GetTextureIndex())}");
+                    asset.AsImage().PatchExtendedTileSheet(pants.texture, null, pantsRect(pants.GetTextureIndex()));
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting sprite for {pants.Name}: {e}");
+                }
+            }
+        }
+        private void injectCharactersFarmerShoeColors(IAssetData asset)
+        {
+            var oldTex = asset.AsImage().Data;
+            Texture2D newTex = new Texture2D(Game1.graphics.GraphicsDevice, oldTex.Width, Math.Max(oldTex.Height, 4096));
+            asset.ReplaceWith(newTex);
+            asset.AsImage().PatchImage(oldTex);
+            Log.trace($"Boots are now ({oldTex.Width}, {Math.Max(oldTex.Height, 4096)})");
+
+            foreach (var boots in Mod.instance.bootss)
+            {
+                try
+                {
+                    Log.verbose($"Injecting {boots.Name} sprites @ {bootsRect(boots.GetTextureIndex())}");
+                    asset.AsImage().PatchExtendedTileSheet(boots.textureColor, null, bootsRect(boots.GetTextureIndex()));
+                }
+                catch (Exception e)
+                {
+                    Log.error($"Exception injecting sprite for {boots.Name}: {e}");
                 }
             }
         }


### PR DESCRIPTION
Rather than linear searching a List<string> every time CanEdit or Edit is called we can just use a dictionary to map from an asset name to a method used for injecting into that asset. CanEdit and Edit will be O(1)-ish instead of O(n).

This also allows better separation of concerns since determining which injection to perform and performing that injection are done in separate methods. 